### PR TITLE
feat: Add remove button for character actions

### DIFF
--- a/webfg-gm-app/src/components/characters/CharacterView.css
+++ b/webfg-gm-app/src/components/characters/CharacterView.css
@@ -149,6 +149,20 @@
   background-color: #0069d9;
 }
 
+.action-buttons {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.remove-action-button {
+  transition: background-color 0.2s;
+}
+
+.remove-action-button:hover {
+  background-color: #c82333 !important;
+}
+
 .overlay {
   position: fixed;
   top: 0;
@@ -363,7 +377,13 @@
     width: 100%;
   }
 
-  .test-action-button {
+  .test-action-button,
+  .remove-action-button {
+    width: 100%;
+  }
+  
+  .action-buttons {
+    flex-direction: column;
     width: 100%;
   }
 

--- a/webfg-gm-app/src/components/characters/CharacterView.js
+++ b/webfg-gm-app/src/components/characters/CharacterView.js
@@ -11,7 +11,8 @@ import {
   MOVE_OBJECT_FROM_READY_TO_EQUIPMENT,
   MOVE_OBJECT_FROM_EQUIPMENT_TO_STASH,
   REMOVE_CONDITION_FROM_CHARACTER,
-  UPDATE_CONDITION_AMOUNT
+  UPDATE_CONDITION_AMOUNT,
+  REMOVE_ACTION_FROM_CHARACTER
 } from "../../graphql/operations";
 import { GET_CHARACTER_WITH_GROUPED } from "../../graphql/computedOperations";
 import { useSelectedCharacter } from "../../context/SelectedCharacterContext";
@@ -122,6 +123,16 @@ const CharacterView = ({ startInEditMode = false }) => {
       console.error("Error updating condition amount:", err);
       setMutationError({ 
         message: err.message || "Error updating condition amount", 
+        stack: err.stack || "No stack trace available."
+      });
+    }
+  });
+
+  const [removeActionFromCharacter] = useMutation(REMOVE_ACTION_FROM_CHARACTER, {
+    onError: (err) => {
+      console.error("Error removing action from character:", err);
+      setMutationError({ 
+        message: err.message || "Error removing action from character", 
         stack: err.stack || "No stack trace available."
       });
     }
@@ -336,6 +347,24 @@ const CharacterView = ({ startInEditMode = false }) => {
       console.error("Error updating condition amount:", err);
       setMutationError({ 
         message: "Failed to update condition amount. " + (err.message || ""),
+        stack: err.stack || "No stack trace available."
+      });
+    }
+  };
+
+  // Handler for removing an action from character
+  const handleRemoveAction = async (actionId) => {
+    try {
+      await removeActionFromCharacter({
+        variables: { characterId, actionId }
+      });
+      
+      // Refetch to update the UI
+      refetch();
+    } catch (err) {
+      console.error("Error removing action:", err);
+      setMutationError({ 
+        message: "Failed to remove action. " + (err.message || ""),
         stack: err.stack || "No stack trace available."
       });
     }
@@ -624,12 +653,32 @@ const CharacterView = ({ startInEditMode = false }) => {
                       </div>
                       <div className="action-description">{action.description}</div>
                     </div>
-                    <button 
-                      onClick={() => handleTestAction(action)} 
-                      className="test-action-button"
-                    >
-                      Test
-                    </button>
+                    <div className="action-buttons">
+                      <button 
+                        onClick={() => handleTestAction(action)} 
+                        className="test-action-button"
+                      >
+                        Test
+                      </button>
+                      <button 
+                        type="button"
+                        className="remove-action-button" 
+                        onClick={() => handleRemoveAction(action.actionId)}
+                        style={{
+                          backgroundColor: '#dc3545',
+                          color: 'white',
+                          padding: '4px 10px',
+                          borderRadius: '4px',
+                          border: 'none',
+                          fontSize: '0.9em',
+                          fontWeight: '500',
+                          cursor: 'pointer',
+                          marginLeft: '8px'
+                        }}
+                      >
+                        Remove
+                      </button>
+                    </div>
                   </div>
                 ))}
               </div>

--- a/webfg-gql/functions/removeActionFromCharacter.js
+++ b/webfg-gql/functions/removeActionFromCharacter.js
@@ -1,0 +1,53 @@
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const { DynamoDBDocumentClient, GetCommand, UpdateCommand } = require('@aws-sdk/lib-dynamodb');
+
+const client = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(client);
+
+exports.handler = async (event) => {
+  const { characterId, actionId } = event.arguments;
+  const charactersTable = process.env.CHARACTERS_TABLE;
+  
+  try {
+    // First, get the character to check if action exists
+    const getResult = await docClient.send(
+      new GetCommand({
+        TableName: charactersTable,
+        Key: { characterId }
+      })
+    );
+    
+    if (!getResult.Item) {
+      throw new Error(`Character with ID ${characterId} not found`);
+    }
+    
+    const character = getResult.Item;
+    const actionIds = character.actionIds || [];
+    
+    // Check if action exists in the character's actions
+    if (!actionIds.includes(actionId)) {
+      return character; // Action doesn't exist, return character unchanged
+    }
+    
+    // Remove the action from the character's actions
+    const updatedActionIds = actionIds.filter(id => id !== actionId);
+    
+    // Update the character with the new action list
+    const updateResult = await docClient.send(
+      new UpdateCommand({
+        TableName: charactersTable,
+        Key: { characterId },
+        UpdateExpression: 'SET actionIds = :actionIds',
+        ExpressionAttributeValues: {
+          ':actionIds': updatedActionIds
+        },
+        ReturnValues: 'ALL_NEW'
+      })
+    );
+    
+    return updateResult.Attributes;
+  } catch (error) {
+    console.error('Error removing action from character:', error);
+    throw error;
+  }
+}; 

--- a/webfg-gql/graphql/action-character-resolvers.yaml
+++ b/webfg-gql/graphql/action-character-resolvers.yaml
@@ -49,6 +49,23 @@ Resources:
         - DynamoDBReadPolicy:
             TableName: !Ref ActionsTableName
 
+  RemoveActionFromCharacterFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../
+      Handler: ./functions/removeActionFromCharacter.handler
+      Runtime: nodejs22.x
+      MemorySize: 1024
+      Timeout: 30
+      Environment:
+        Variables:
+          CHARACTERS_TABLE: !Ref CharactersTableName
+      Policies:
+        - DynamoDBReadPolicy:
+            TableName: !Ref CharactersTableName
+        - DynamoDBWritePolicy:
+            TableName: !Ref CharactersTableName
+
   AddActionToCharacterDataSource:
     Type: AWS::AppSync::DataSource
     Properties:
@@ -68,6 +85,16 @@ Resources:
       ServiceRoleArn: !Ref AppSyncLambdaServiceRoleArn
       LambdaConfig:
         LambdaFunctionArn: !GetAtt GetCharacterActionsFunction.Arn
+
+  RemoveActionFromCharacterDataSource:
+    Type: AWS::AppSync::DataSource
+    Properties:
+      ApiId: !Ref ApiId
+      Name: RemoveActionFromCharacter
+      Type: AWS_LAMBDA
+      ServiceRoleArn: !Ref AppSyncLambdaServiceRoleArn
+      LambdaConfig:
+        LambdaFunctionArn: !GetAtt RemoveActionFromCharacterFunction.Arn
 
   AddActionToCharacterResolver:
     Type: AWS::AppSync::Resolver
@@ -104,3 +131,21 @@ Resources:
         }
       ResponseMappingTemplate: |
         $util.toJson($context.result)
+
+  RemoveActionFromCharacterResolver:
+    Type: AWS::AppSync::Resolver
+    Properties:
+      ApiId: !Ref ApiId
+      TypeName: Mutation
+      FieldName: removeActionFromCharacter
+      DataSourceName: !GetAtt RemoveActionFromCharacterDataSource.Name
+      RequestMappingTemplate: |
+        {
+          "version": "2018-05-29",
+          "operation": "Invoke",
+          "payload": {
+            "arguments": $util.toJson($ctx.args)
+          }
+        }
+      ResponseMappingTemplate: |
+        $util.toJson($ctx.result)

--- a/webfg-gql/src/tests/functions/removeActionFromCharacter.test.js
+++ b/webfg-gql/src/tests/functions/removeActionFromCharacter.test.js
@@ -1,0 +1,93 @@
+const { handler } = require('../../../functions/removeActionFromCharacter');
+
+describe('removeActionFromCharacter', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      CHARACTERS_TABLE: 'test-characters-table'
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('input validation', () => {
+    it('should throw error when character not found', async () => {
+      const event = {
+        arguments: {
+          characterId: 'char123',
+          actionId: 'action456'
+        }
+      };
+
+      // Mock DynamoDB to return no character
+      const mockGet = jest.fn().mockResolvedValue({ Item: null });
+      jest.doMock('@aws-sdk/lib-dynamodb', () => ({
+        DynamoDBDocumentClient: {
+          from: jest.fn(() => ({
+            send: mockGet
+          }))
+        },
+        GetCommand: jest.fn()
+      }));
+
+      await expect(handler(event)).rejects.toThrow('Character with ID char123 not found');
+    });
+  });
+
+  describe('successful removal', () => {
+    it('should remove action from character actionIds', async () => {
+      const characterId = 'char123';
+      const actionId = 'action456';
+      
+      const mockCharacter = {
+        characterId,
+        name: 'Test Character',
+        actionIds: ['action123', 'action456', 'action789']
+      };
+
+      const updatedCharacter = {
+        ...mockCharacter,
+        actionIds: ['action123', 'action789']
+      };
+
+      const event = {
+        arguments: { characterId, actionId }
+      };
+
+      // This is a simplified test - in a real implementation you would
+      // properly mock the DynamoDB client
+      // For now, let's just test the basic structure
+      expect(event.arguments.characterId).toBe(characterId);
+      expect(event.arguments.actionId).toBe(actionId);
+    });
+
+    it('should return character unchanged when action does not exist', async () => {
+      const characterId = 'char123';
+      const actionId = 'action999';
+      
+      const event = {
+        arguments: { characterId, actionId }
+      };
+
+      expect(event.arguments.characterId).toBe(characterId);
+      expect(event.arguments.actionId).toBe(actionId);
+    });
+
+    it('should handle character with no actionIds', async () => {
+      const characterId = 'char123';
+      const actionId = 'action456';
+      
+      const event = {
+        arguments: { characterId, actionId }
+      };
+
+      expect(event.arguments.characterId).toBe(characterId);
+      expect(event.arguments.actionId).toBe(actionId);
+    });
+  });
+});

--- a/webfg-gql/src/tests/functions/removeActionFromCharacter.test.js
+++ b/webfg-gql/src/tests/functions/removeActionFromCharacter.test.js
@@ -24,22 +24,50 @@ describe('removeActionFromCharacter', () => {
         }
       };
 
-      // Mock DynamoDB to return no character
-      const mockGet = jest.fn().mockResolvedValue({ Item: null });
-      jest.doMock('@aws-sdk/lib-dynamodb', () => ({
-        DynamoDBDocumentClient: {
-          from: jest.fn(() => ({
-            send: mockGet
-          }))
-        },
-        GetCommand: jest.fn()
-      }));
+      // Mock GetCommand to return no character
+      global.mockDynamoSend.mockResolvedValueOnce({ Item: null });
 
       await expect(handler(event)).rejects.toThrow('Character with ID char123 not found');
+      
+      // Verify the GetCommand was called
+      expect(global.mockDynamoSend).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle missing characterId', async () => {
+      const event = {
+        arguments: {
+          actionId: 'action456'
+        }
+      };
+
+      global.mockDynamoSend.mockResolvedValueOnce({ Item: null });
+
+      await expect(handler(event)).rejects.toThrow();
+    });
+
+    it('should handle missing actionId', async () => {
+      const event = {
+        arguments: {
+          characterId: 'char123'
+        }
+      };
+
+      const mockCharacter = {
+        characterId: 'char123',
+        name: 'Test Character',
+        actionIds: ['action1', 'action2']
+      };
+
+      global.mockDynamoSend.mockResolvedValueOnce({ Item: mockCharacter });
+
+      const result = await handler(event);
+      
+      expect(result).toEqual(mockCharacter);
+      expect(global.mockDynamoSend).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe('successful removal', () => {
+  describe('removing actions', () => {
     it('should remove action from character actionIds', async () => {
       const characterId = 'char123';
       const actionId = 'action456';
@@ -59,35 +87,428 @@ describe('removeActionFromCharacter', () => {
         arguments: { characterId, actionId }
       };
 
-      // This is a simplified test - in a real implementation you would
-      // properly mock the DynamoDB client
-      // For now, let's just test the basic structure
-      expect(event.arguments.characterId).toBe(characterId);
-      expect(event.arguments.actionId).toBe(actionId);
+      global.mockDynamoSend
+        .mockResolvedValueOnce({ Item: mockCharacter })
+        .mockResolvedValueOnce({ Attributes: updatedCharacter });
+
+      const result = await handler(event);
+
+      expect(result).toEqual(updatedCharacter);
+      expect(result.actionIds).not.toContain(actionId);
+      expect(result.actionIds).toHaveLength(2);
+      expect(global.mockDynamoSend).toHaveBeenCalledTimes(2);
     });
 
     it('should return character unchanged when action does not exist', async () => {
       const characterId = 'char123';
       const actionId = 'action999';
       
+      const mockCharacter = {
+        characterId,
+        name: 'Test Character',
+        actionIds: ['action123', 'action456', 'action789']
+      };
+
       const event = {
         arguments: { characterId, actionId }
       };
 
-      expect(event.arguments.characterId).toBe(characterId);
-      expect(event.arguments.actionId).toBe(actionId);
+      global.mockDynamoSend.mockResolvedValueOnce({ Item: mockCharacter });
+
+      const result = await handler(event);
+
+      expect(result).toEqual(mockCharacter);
+      expect(global.mockDynamoSend).toHaveBeenCalledTimes(1);
     });
 
     it('should handle character with no actionIds', async () => {
       const characterId = 'char123';
       const actionId = 'action456';
       
+      const mockCharacter = {
+        characterId,
+        name: 'Test Character'
+        // No actionIds property
+      };
+
       const event = {
         arguments: { characterId, actionId }
       };
 
-      expect(event.arguments.characterId).toBe(characterId);
-      expect(event.arguments.actionId).toBe(actionId);
+      global.mockDynamoSend.mockResolvedValueOnce({ Item: mockCharacter });
+
+      const result = await handler(event);
+
+      expect(result).toEqual(mockCharacter);
+      expect(global.mockDynamoSend).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle character with empty actionIds array', async () => {
+      const characterId = 'char123';
+      const actionId = 'action456';
+      
+      const mockCharacter = {
+        characterId,
+        name: 'Test Character',
+        actionIds: []
+      };
+
+      const event = {
+        arguments: { characterId, actionId }
+      };
+
+      global.mockDynamoSend.mockResolvedValueOnce({ Item: mockCharacter });
+
+      const result = await handler(event);
+
+      expect(result).toEqual(mockCharacter);
+      expect(global.mockDynamoSend).toHaveBeenCalledTimes(1);
+    });
+
+    it('should remove first action from array', async () => {
+      const characterId = 'char123';
+      const actionId = 'action123';
+      
+      const mockCharacter = {
+        characterId,
+        name: 'Test Character',
+        actionIds: ['action123', 'action456', 'action789']
+      };
+
+      const updatedCharacter = {
+        ...mockCharacter,
+        actionIds: ['action456', 'action789']
+      };
+
+      const event = {
+        arguments: { characterId, actionId }
+      };
+
+      global.mockDynamoSend
+        .mockResolvedValueOnce({ Item: mockCharacter })
+        .mockResolvedValueOnce({ Attributes: updatedCharacter });
+
+      const result = await handler(event);
+
+      expect(result).toEqual(updatedCharacter);
+      expect(result.actionIds).toEqual(['action456', 'action789']);
+    });
+
+    it('should remove last action from array', async () => {
+      const characterId = 'char123';
+      const actionId = 'action789';
+      
+      const mockCharacter = {
+        characterId,
+        name: 'Test Character',
+        actionIds: ['action123', 'action456', 'action789']
+      };
+
+      const updatedCharacter = {
+        ...mockCharacter,
+        actionIds: ['action123', 'action456']
+      };
+
+      const event = {
+        arguments: { characterId, actionId }
+      };
+
+      global.mockDynamoSend
+        .mockResolvedValueOnce({ Item: mockCharacter })
+        .mockResolvedValueOnce({ Attributes: updatedCharacter });
+
+      const result = await handler(event);
+
+      expect(result).toEqual(updatedCharacter);
+      expect(result.actionIds).toEqual(['action123', 'action456']);
+    });
+
+    it('should remove middle action from array', async () => {
+      const characterId = 'char123';
+      const actionId = 'action456';
+      
+      const mockCharacter = {
+        characterId,
+        name: 'Test Character',
+        actionIds: ['action123', 'action456', 'action789']
+      };
+
+      const updatedCharacter = {
+        ...mockCharacter,
+        actionIds: ['action123', 'action789']
+      };
+
+      const event = {
+        arguments: { characterId, actionId }
+      };
+
+      global.mockDynamoSend
+        .mockResolvedValueOnce({ Item: mockCharacter })
+        .mockResolvedValueOnce({ Attributes: updatedCharacter });
+
+      const result = await handler(event);
+
+      expect(result).toEqual(updatedCharacter);
+      expect(result.actionIds).toEqual(['action123', 'action789']);
+    });
+
+    it('should handle removing only action from character', async () => {
+      const characterId = 'char123';
+      const actionId = 'action456';
+      
+      const mockCharacter = {
+        characterId,
+        name: 'Test Character',
+        actionIds: ['action456']
+      };
+
+      const updatedCharacter = {
+        ...mockCharacter,
+        actionIds: []
+      };
+
+      const event = {
+        arguments: { characterId, actionId }
+      };
+
+      global.mockDynamoSend
+        .mockResolvedValueOnce({ Item: mockCharacter })
+        .mockResolvedValueOnce({ Attributes: updatedCharacter });
+
+      const result = await handler(event);
+
+      expect(result).toEqual(updatedCharacter);
+      expect(result.actionIds).toHaveLength(0);
+    });
+
+    it('should remove all occurrences if action appears multiple times', async () => {
+      const characterId = 'char123';
+      const actionId = 'action456';
+      
+      const mockCharacter = {
+        characterId,
+        name: 'Test Character',
+        actionIds: ['action123', 'action456', 'action789', 'action456']
+      };
+
+      const updatedCharacter = {
+        ...mockCharacter,
+        actionIds: ['action123', 'action789']
+      };
+
+      const event = {
+        arguments: { characterId, actionId }
+      };
+
+      global.mockDynamoSend
+        .mockResolvedValueOnce({ Item: mockCharacter })
+        .mockResolvedValueOnce({ Attributes: updatedCharacter });
+
+      const result = await handler(event);
+
+      expect(result).toEqual(updatedCharacter);
+      expect(result.actionIds).not.toContain(actionId);
+      expect(result.actionIds).toHaveLength(2);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle DynamoDB get errors', async () => {
+      const event = {
+        arguments: {
+          characterId: 'char123',
+          actionId: 'action456'
+        }
+      };
+
+      global.mockDynamoSend.mockRejectedValueOnce(new Error('DynamoDB Error'));
+
+      await expect(handler(event)).rejects.toThrow('DynamoDB Error');
+    });
+
+    it('should handle DynamoDB update errors', async () => {
+      const characterId = 'char123';
+      const actionId = 'action456';
+      
+      const mockCharacter = {
+        characterId,
+        name: 'Test Character',
+        actionIds: ['action123', 'action456', 'action789']
+      };
+
+      const event = {
+        arguments: { characterId, actionId }
+      };
+
+      global.mockDynamoSend
+        .mockResolvedValueOnce({ Item: mockCharacter })
+        .mockRejectedValueOnce(new Error('Update Error'));
+
+      await expect(handler(event)).rejects.toThrow('Update Error');
+    });
+  });
+
+  describe('environment variables', () => {
+    it('should use CHARACTERS_TABLE environment variable', async () => {
+      const event = {
+        arguments: {
+          characterId: 'char123',
+          actionId: 'action456'
+        }
+      };
+
+      global.mockDynamoSend.mockResolvedValueOnce({ Item: null });
+
+      await expect(handler(event)).rejects.toThrow();
+      
+      expect(global.mockDynamoSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          TableName: 'test-characters-table'
+        })
+      );
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle special characters in action IDs', async () => {
+      const characterId = 'char123';
+      const actionId = 'action-with-special@chars!';
+      
+      const mockCharacter = {
+        characterId,
+        name: 'Test Character',
+        actionIds: ['action123', 'action-with-special@chars!', 'action789']
+      };
+
+      const updatedCharacter = {
+        ...mockCharacter,
+        actionIds: ['action123', 'action789']
+      };
+
+      const event = {
+        arguments: { characterId, actionId }
+      };
+
+      global.mockDynamoSend
+        .mockResolvedValueOnce({ Item: mockCharacter })
+        .mockResolvedValueOnce({ Attributes: updatedCharacter });
+
+      const result = await handler(event);
+
+      expect(result).toEqual(updatedCharacter);
+      expect(result.actionIds).not.toContain(actionId);
+    });
+
+    it('should handle very long action IDs', async () => {
+      const characterId = 'char123';
+      const actionId = 'a'.repeat(100);
+      
+      const mockCharacter = {
+        characterId,
+        name: 'Test Character',
+        actionIds: ['action123', actionId, 'action789']
+      };
+
+      const updatedCharacter = {
+        ...mockCharacter,
+        actionIds: ['action123', 'action789']
+      };
+
+      const event = {
+        arguments: { characterId, actionId }
+      };
+
+      global.mockDynamoSend
+        .mockResolvedValueOnce({ Item: mockCharacter })
+        .mockResolvedValueOnce({ Attributes: updatedCharacter });
+
+      const result = await handler(event);
+
+      expect(result).toEqual(updatedCharacter);
+      expect(result.actionIds).not.toContain(actionId);
+    });
+
+    it('should handle large action arrays', async () => {
+      const characterId = 'char123';
+      const actionId = 'action50';
+      
+      const actionIds = Array.from({ length: 100 }, (_, i) => `action${i}`);
+      
+      const mockCharacter = {
+        characterId,
+        name: 'Test Character',
+        actionIds
+      };
+
+      const updatedCharacter = {
+        ...mockCharacter,
+        actionIds: actionIds.filter(id => id !== actionId)
+      };
+
+      const event = {
+        arguments: { characterId, actionId }
+      };
+
+      global.mockDynamoSend
+        .mockResolvedValueOnce({ Item: mockCharacter })
+        .mockResolvedValueOnce({ Attributes: updatedCharacter });
+
+      const result = await handler(event);
+
+      expect(result).toEqual(updatedCharacter);
+      expect(result.actionIds).not.toContain(actionId);
+      expect(result.actionIds).toHaveLength(99);
+    });
+
+    it('should preserve array order when removing actions', async () => {
+      const characterId = 'char123';
+      const actionId = 'action456';
+      
+      const mockCharacter = {
+        characterId,
+        name: 'Test Character',
+        actionIds: ['action123', 'action456', 'action789', 'action999']
+      };
+
+      const updatedCharacter = {
+        ...mockCharacter,
+        actionIds: ['action123', 'action789', 'action999']
+      };
+
+      const event = {
+        arguments: { characterId, actionId }
+      };
+
+      global.mockDynamoSend
+        .mockResolvedValueOnce({ Item: mockCharacter })
+        .mockResolvedValueOnce({ Attributes: updatedCharacter });
+
+      const result = await handler(event);
+
+      expect(result).toEqual(updatedCharacter);
+      expect(result.actionIds).toEqual(['action123', 'action789', 'action999']);
+    });
+
+    it('should handle null action ID gracefully', async () => {
+      const characterId = 'char123';
+      const actionId = null;
+      
+      const mockCharacter = {
+        characterId,
+        name: 'Test Character',
+        actionIds: ['action123', 'action456', 'action789']
+      };
+
+      const event = {
+        arguments: { characterId, actionId }
+      };
+
+      global.mockDynamoSend.mockResolvedValueOnce({ Item: mockCharacter });
+
+      const result = await handler(event);
+
+      expect(result).toEqual(mockCharacter);
+      expect(global.mockDynamoSend).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add remove button to character view to allow removing actions from character's actionIds
- Implement GraphQL mutation call to update character without the removed action
- Ensure proper UI feedback and error handling

## Changes Made
- Import REMOVE_ACTION_FROM_CHARACTER mutation in CharacterView.js
- Add removeActionFromCharacter mutation hook with proper error handling
- Implement handleRemoveAction function that removes the action and refetches character data
- Add remove button UI next to the test button in the actions section
- Update CharacterView.css to properly style the action buttons container
- Add responsive styles for mobile layout to ensure buttons stack vertically on small screens

## Test plan
- [ ] Manually test removing actions from character view
- [ ] Verify character's actionIds are updated correctly
- [ ] Ensure UI updates immediately after removal
- [ ] Test mobile responsive layout
- [ ] Run all unit and E2E tests

🤖 Generated with [Claude Code](https://claude.ai/code)