### PR TITLE
feat: Add character race system with attribute restrictions

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -46,7 +46,7 @@ jobs:
         run: npm install
 
       - name: Run GM App unit tests with coverage
-        run: npm run test:coverage
+        run: npm run test:ci
 
   deploy-gql-qa:
     name: Deploy GQL to QA (PR-${{ github.event.number }})

--- a/webfg-gm-app/package.json
+++ b/webfg-gm-app/package.json
@@ -24,7 +24,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "test:coverage": "react-scripts test --coverage --passWithNoTests",
-    "test:ci": "react-scripts test --coverage --passWithNoTests --watchAll=false",
+    "test:ci": "react-scripts test --coverage --passWithNoTests --watchAll=false --ci",
     "test:unit": "react-scripts test --testPathPattern=__tests__ --watchAll=false",
     "start:bg": "nohup env-cmd -f .env.dev react-scripts start > webfg-gm-app.log 2>&1 & echo \\$\\! > webfg-gm-app.pid",
     "stop:bg": "if [ -f webfg-gm-app.pid ]; then kill \\$\\(cat webfg-gm-app.pid\\) && rm webfg-gm-app.pid && echo 'Stopped server.'; else echo 'Server not running (no PID file)'; fi",

--- a/webfg-gm-app/src/__tests__/components/characters/CharacterDetails.test.js
+++ b/webfg-gm-app/src/__tests__/components/characters/CharacterDetails.test.js
@@ -74,7 +74,9 @@ describe('CharacterDetails Component', () => {
       </CharacterDetailsWrapper>
     );
     
-    expect(screen.getByText('HUMAN')).toBeInTheDocument();
+    // Check that category is displayed (there might be multiple HUMAN texts now with race)
+    const categoryRow = screen.getByText('Category:').parentElement;
+    expect(categoryRow).toHaveTextContent('HUMAN');
   });
 
   test('displays character description', () => {
@@ -147,7 +149,9 @@ describe('CharacterDetails Component', () => {
       </CharacterDetailsWrapper>
     );
     
-    expect(screen.getByText('HUMAN')).toBeInTheDocument();
+    // Check that category is displayed (there might be multiple HUMAN texts now with race)
+    const categoryRow = screen.getByText('Category:').parentElement;
+    expect(categoryRow).toHaveTextContent('HUMAN');
   });
 
   test('handles missing attributes gracefully', () => {
@@ -163,7 +167,9 @@ describe('CharacterDetails Component', () => {
       </CharacterDetailsWrapper>
     );
     
-    expect(screen.getByText('HUMAN')).toBeInTheDocument();
+    // Check that category is displayed (there might be multiple HUMAN texts now with race)
+    const categoryRow = screen.getByText('Category:').parentElement;
+    expect(categoryRow).toHaveTextContent('HUMAN');
   });
 
   test('applies correct CSS classes', () => {

--- a/webfg-gm-app/src/__tests__/components/forms/CharacterForm.test.js
+++ b/webfg-gm-app/src/__tests__/components/forms/CharacterForm.test.js
@@ -93,7 +93,11 @@ describe('CharacterForm Component', () => {
       </CharacterFormWrapper>
     );
     
-    expect(screen.getByDisplayValue('HUMAN')).toBeInTheDocument();
+    // Find the Category label and check its associated select
+    const categoryLabel = screen.getByText('Category');
+    const categorySelect = categoryLabel.parentElement.querySelector('select');
+    expect(categorySelect).toBeInTheDocument();
+    expect(categorySelect.value).toBe('HUMAN'); // Default value
   });
 
   test('displays will input field', () => {
@@ -154,7 +158,11 @@ describe('CharacterForm Component', () => {
     );
     
     expect(screen.getByDisplayValue('Existing Character')).toBeInTheDocument();
-    expect(screen.getByDisplayValue('HUMAN')).toBeInTheDocument();
+    
+    // Check that category is set to HUMAN
+    const categoryLabel = screen.getByText('Category');
+    const categorySelect = categoryLabel.parentElement.querySelector('select');
+    expect(categorySelect.value).toBe('HUMAN');
     
     // Find the Will label and check its value
     const willLabel = screen.getByText('Will');
@@ -183,7 +191,9 @@ describe('CharacterForm Component', () => {
       </CharacterFormWrapper>
     );
     
-    const categorySelect = screen.getByDisplayValue('HUMAN');
+    // Get the category select specifically by finding the Category label first
+    const categoryLabel = screen.getByText('Category');
+    const categorySelect = categoryLabel.parentElement.querySelector('select');
     fireEvent.change(categorySelect, { target: { value: 'TREPIDITE' } });
     
     expect(categorySelect.value).toBe('TREPIDITE');

--- a/webfg-gm-app/src/components/characters/CharacterDetails.js
+++ b/webfg-gm-app/src/components/characters/CharacterDetails.js
@@ -72,6 +72,10 @@ const CharacterDetails = ({ character, onUpdate }) => {
             <td>Category:</td>
             <td>{character.characterCategory}</td>
           </tr>
+          <tr>
+            <td>Race:</td>
+            <td>{character.race || 'HUMAN'}</td>
+          </tr>
           {character.description && (
             <tr>
               <td>Description:</td>

--- a/webfg-gm-app/src/components/forms/CharacterForm.js
+++ b/webfg-gm-app/src/components/forms/CharacterForm.js
@@ -304,12 +304,13 @@ const CharacterForm = ({ character, isEditing = false, onClose, onSuccess }) => 
     try {
       
       // Prepare the input data for mutation
+      console.log('DEBUG: formData.raceOverride before submission:', formData.raceOverride, typeof formData.raceOverride);
       const input = {
         name: formData.name,
         description: formData.description || "",
         characterCategory: formData.characterCategory,
         race: formData.race || "HUMAN",
-        raceOverride: formData.raceOverride || false,
+        raceOverride: formData.raceOverride === true,
         will: formData.will !== null && formData.will !== undefined && formData.will !== '' ? parseInt(formData.will) : 0,
         mind: formData.mind,
         special: formData.special,
@@ -320,6 +321,7 @@ const CharacterForm = ({ character, isEditing = false, onClose, onSuccess }) => 
         targetAttributeTotal: formData.targetAttributeTotal || calculateDefaultTargetTotal()
       };
       
+      console.log('DEBUG: input.raceOverride after preparation:', input.raceOverride, typeof input.raceOverride);
       
       // Add all attributes dynamically
       console.log('DEBUG: formData before submission:', formData);

--- a/webfg-gm-app/src/graphql/operations.js
+++ b/webfg-gm-app/src/graphql/operations.js
@@ -92,6 +92,8 @@ export const GET_CHARACTER = gql`
       name
       description
       characterCategory
+      race
+      raceOverride
       will
       mind { thoughtId affinity knowledge location }
       mindThoughts { thoughtId name description }
@@ -458,6 +460,8 @@ export const CREATE_CHARACTER = gql`
       name
       description
       characterCategory
+      race
+      raceOverride
       will
       mind { thoughtId affinity knowledge location }
       mindThoughts { thoughtId name description }
@@ -500,6 +504,8 @@ export const UPDATE_CHARACTER = gql`
       name
       description
       characterCategory
+      race
+      raceOverride
       will
       mind { thoughtId affinity knowledge location }
       mindThoughts { thoughtId name description }

--- a/webfg-gql/functions/createCharacter.js
+++ b/webfg-gql/functions/createCharacter.js
@@ -24,7 +24,7 @@ exports.handler = async (event) => {
     description: input.description,
     characterCategory: input.characterCategory,
     race: input.race || 'HUMAN', // Default to HUMAN for backwards compatibility
-    raceOverride: input.raceOverride || false, // Default to false
+    raceOverride: input.raceOverride !== undefined ? Boolean(input.raceOverride) : false, // Ensure proper boolean
     will: input.will || 0,
     fatigue: input.fatigue || 0,
     values: input.values || [],

--- a/webfg-gql/functions/createCharacter.js
+++ b/webfg-gql/functions/createCharacter.js
@@ -23,6 +23,8 @@ exports.handler = async (event) => {
     nameLowerCase: input.name.toLowerCase(),
     description: input.description,
     characterCategory: input.characterCategory,
+    race: input.race || 'HUMAN', // Default to HUMAN for backwards compatibility
+    raceOverride: input.raceOverride || false, // Default to false
     will: input.will || 0,
     fatigue: input.fatigue || 0,
     values: input.values || [],

--- a/webfg-gql/functions/getCharacter.js
+++ b/webfg-gql/functions/getCharacter.js
@@ -66,6 +66,14 @@ exports.handler = async (event) => {
             character.mind = [];
         }
 
+        // Handle race field for backward compatibility
+        if (!character.race) {
+            character.race = 'HUMAN';
+        }
+        if (character.raceOverride === undefined) {
+            character.raceOverride = false;
+        }
+
         console.log(`Successfully retrieved character: ${character.name} (${characterId})`);
         return character;
 

--- a/webfg-gql/functions/getCharacter.js
+++ b/webfg-gql/functions/getCharacter.js
@@ -37,12 +37,12 @@ exports.handler = async (event) => {
             }
         };
 
-        // List of all expected attributes
+        // List of all expected attributes (updated to match current schema)
         const allAttributes = [
             'speed', 'weight', 'size', 'armour', 'endurance', 'lethality', 'complexity',
-            'strength', 'dexterity', 'agility', 'perception', 'resolve', 
+            'strength', 'dexterity', 'agility', 'obscurity', 'resolve', 
             'morale', 'intelligence', 'charisma', 'seeing', 'hearing', 
-            'smelling', 'light', 'noise', 'scent'
+            'light', 'noise'
         ];
 
         // Add default values for any missing attributes and fix legacy data format
@@ -70,8 +70,12 @@ exports.handler = async (event) => {
         if (!character.race) {
             character.race = 'HUMAN';
         }
-        if (character.raceOverride === undefined) {
+        // Explicitly handle raceOverride boolean field
+        if (character.raceOverride === undefined || character.raceOverride === null) {
             character.raceOverride = false;
+        } else {
+            // Ensure it's a proper boolean value
+            character.raceOverride = Boolean(character.raceOverride);
         }
 
         console.log(`Successfully retrieved character: ${character.name} (${characterId})`);

--- a/webfg-gql/functions/updateCharacter.js
+++ b/webfg-gql/functions/updateCharacter.js
@@ -41,6 +41,8 @@ exports.handler = async (event) => {
   }
   addUpdateField("description", input.description);
   addUpdateField("characterCategory", input.characterCategory);
+  addUpdateField("race", input.race);
+  addUpdateField("raceOverride", input.raceOverride);
   addUpdateField("will", input.will);
   addUpdateField("fatigue", input.fatigue);
   addUpdateField("values", input.values);

--- a/webfg-gql/functions/updateCharacter.js
+++ b/webfg-gql/functions/updateCharacter.js
@@ -29,7 +29,12 @@ exports.handler = async (event) => {
     if (fieldValue !== undefined) {
       updateExpressionParts.push(`#${attributeName} = :${attributeName}`);
       expressionAttributeNames[`#${attributeName}`] = fieldName;
-      expressionAttributeValues[`:${attributeName}`] = fieldValue;
+      // Special handling for boolean fields to ensure they're stored as proper booleans
+      if (fieldName === 'raceOverride' && fieldValue !== null) {
+        expressionAttributeValues[`:${attributeName}`] = Boolean(fieldValue);
+      } else {
+        expressionAttributeValues[`:${attributeName}`] = fieldValue;
+      }
     }
   };
 

--- a/webfg-gql/package.json
+++ b/webfg-gql/package.json
@@ -33,8 +33,8 @@
     "uuid": "^11.1.0"
   },
   "config": {
-    "qa_schema": "v123",
-    "prod_schema": "v123",
+    "qa_schema": "v124",
+    "prod_schema": "v124",
     "stack_name": "webfg-gql"
   },
   "devDependencies": {

--- a/webfg-gql/package.json
+++ b/webfg-gql/package.json
@@ -33,8 +33,8 @@
     "uuid": "^11.1.0"
   },
   "config": {
-    "qa_schema": "v124",
-    "prod_schema": "v124",
+    "qa_schema": "v125",
+    "prod_schema": "v125",
     "stack_name": "webfg-gql"
   },
   "devDependencies": {

--- a/webfg-gql/schema.graphql
+++ b/webfg-gql/schema.graphql
@@ -57,6 +57,8 @@ type Character {
   nameLowerCase: String
   description: String
   characterCategory: CharacterCategory!
+  race: CharacterRace
+  raceOverride: Boolean
   will: Int!
   fatigue: Int # Deprecated - no longer used, kept for backwards compatibility
 
@@ -119,6 +121,14 @@ enum CharacterCategory {
   TYVIR
 }
 
+enum CharacterRace {
+  HUMAN
+  ANTHRO
+  CARVED
+  TREPIDITE
+  DHYARMA
+}
+
 type CharacterAttribute {
   attribute: Attribute!
 }
@@ -131,6 +141,8 @@ input CharacterInput {
   name: String!
   description: String
   characterCategory: CharacterCategory!
+  race: CharacterRace
+  raceOverride: Boolean
   will: Int!
   fatigue: Int # Deprecated - no longer used, kept for backwards compatibility
   mind: [MindThoughtInput]

--- a/webfg-gql/schema/Character.graphql
+++ b/webfg-gql/schema/Character.graphql
@@ -4,6 +4,8 @@ type Character {
   nameLowerCase: String
   description: String
   characterCategory: CharacterCategory!
+  race: CharacterRace
+  raceOverride: Boolean
   will: Int!
   fatigue: Int # Deprecated - no longer used, kept for backwards compatibility
 
@@ -66,6 +68,14 @@ enum CharacterCategory {
   TYVIR
 }
 
+enum CharacterRace {
+  HUMAN
+  ANTHRO
+  CARVED
+  TREPIDITE
+  DHYARMA
+}
+
 type CharacterAttribute {
   attribute: Attribute!
 }
@@ -78,6 +88,8 @@ input CharacterInput {
   name: String!
   description: String
   characterCategory: CharacterCategory!
+  race: CharacterRace
+  raceOverride: Boolean
   will: Int!
   fatigue: Int # Deprecated - no longer used, kept for backwards compatibility
   mind: [MindThoughtInput]


### PR DESCRIPTION
## Summary
- Add race field to characters (human, anthro, carved, trepidite, dhyarma)
- Add raceOverride boolean field to allow GM to bypass race restrictions
- Implement race-based attribute validation for humans:
  - Restricted attributes (armor, endurance, lethality, complexity, obscurity, light) are fixed at 10
  - Other attributes must be between 5-20 range
  - Restrictions can be bypassed with override checkbox

## Changes Made
- **Backend (webfg-gql):**
  - Added CharacterRace enum to GraphQL schema
  - Added race and raceOverride fields to Character type and CharacterInput
  - Updated createCharacter.js and updateCharacter.js to handle new fields
  - Added backwards compatibility in getCharacter.js (defaults to HUMAN)
  - Incremented schema versions to v124

- **Frontend (webfg-gm-app):**
  - Updated GraphQL operations to include race fields
  - Added race display to character detail view (appears under category)
  - Added race dropdown and override checkbox to character form
  - Implemented real-time validation with visual feedback:
    - Disabled input fields for restricted attributes when human race
    - Range validation for non-restricted attributes (5-20)
    - Visual indicators showing restrictions
    - Submit button blocked until restrictions satisfied

## Test plan
- [ ] Test character creation with human race (restrictions enforced)
- [ ] Test character creation with other races (no restrictions)
- [ ] Test override checkbox functionality
- [ ] Test editing existing characters (backwards compatibility)
- [ ] Verify race field displays correctly in character view
- [ ] Test form validation prevents submission when restrictions violated

🤖 Generated with [Claude Code](https://claude.ai/code)